### PR TITLE
Include early ALL.NET titles

### DIFF
--- a/sega/identifiers.md
+++ b/sega/identifiers.md
@@ -322,7 +322,7 @@ Example:
 
 ## Game ID
 
-Seems to have been introduced around the start of ALL.NET and used from at least the Lindbergh onwards, possibly earlier.
+Seems to have been introduced around the start of ALL.NET and used from Naomi 2/Atomiswave onwards.
 
 Format: `S[BD][A-Z]{2}`. `SC**` may be developer IDs?
 
@@ -331,6 +331,8 @@ Examples:
 * `SDCH`: Mario & Sonic at the Rio Olympic Games
 
 Seem to be allocated (semi-)sequentially and roll over when `Z` is reached.
+
+Very early ALL.NET games (Such as VF4 and VF4 Evolution) do not include the S in their game ID.
 
 ## Media ID
 


### PR DESCRIPTION
The naomi 2/atomiswave im pretty sure are the earliest systems to use all.net. Atomiswave may well have been earlier than naomi 2 but ive only researched naomi 2 games.

The naomi 2 uses the ethernet port on the netdimm to link up to all.net. The netdimm MUST be set to DHCP mode and cannot have a static IP set (Or the game will time out trying to connect and never send anything). The atomiswave has a dedicated all.net module that can be plugged into one of the expansion ports (Though im unsure how it works apart from it requires a keychip).

Early naomi 2 games (Such as virtua fighter 4 and virtua fighter 4 evolution) do not include the S at the beginning of their game IDs, the game ID is also hardcoded into the auth request for these games.

Virtua fighter 4s auth request: `ip=%s&game_id=BDM&ver=1.00&serial=%s`
Virtua fighter 4 Evos auth request: `ip=%s&game_id=BFB&ver=1.00&serial=%s`
Virtua fighter 4 Final tuned auth request: `game_id=%s&ver=%s&serial=%s&ip=%s&firm_ver=%02X%02X&boot_ver=%02X%02X&encode=Shift_JIS`

Virtua fighter 4 Final tuned (To my knowledge) is the first all.net game to follow the current game ID naming scheme (As the code is SBHX). Though VF4 and VF4 evos game ID does not start with an S they still seem to fit the current naming scheme if you add the S to them (SBDM and SBFB respectively).