### PR TITLE
Add another Type X+ board variant

### DIFF
--- a/taito/boards.md
+++ b/taito/boards.md
@@ -23,7 +23,7 @@
 |  005B | P4 2.8GHz  | 512MB | 9600XT  | BG4-TUNED_KIT M9007072A VER2.04JPN                                                  |
 |  011A | P4 3.0GHz  | 512MB | X580PRO | SO2 (せンシノキオク)                                                                  |
 |  012A | P4 2.8GHz  | 512MB | 9600XT  |                                                                                     |
-|  013A | P4 2.8GHz  | 512MB | 9600PRO | Used in BG4 Tuned Pro cabinets                                                      |
+|  013A | P4 2.8GHz  | 512MB | 9800PRO | Used in BG4 Tuned Pro cabinets                                                      |
 |  024A | P4 2.8Ghz  | 1GB   | 9800PRO | HALF-LIFE2 VER2.0 Ver.2.07a-JPN                                                     |
 
 ## Type X7

--- a/taito/boards.md
+++ b/taito/boards.md
@@ -19,10 +19,11 @@
 |    ID | CPU        | RAM   | GPU     | Notes                                                                               |
 |-------|------------|-------|---------|-------------------------------------------------------------------------------------|
 |  005  | P4 2.8GHz  | 512MB | 9600XT  | BG4-TUNED-KIT VER2.04JPN                                                            |
-|  005A | P4 2.8GHz  | 512MB | 9600XT  |                                                                                     |
+|  005A | P4 2.8GHz  | 512MB | 9600XT  | BG4 2.03 GBR                                                                                    |
 |  005B | P4 2.8GHz  | 512MB | 9600XT  | BG4-TUNED_KIT M9007072A VER2.04JPN                                                  |
 |  011A | P4 3.0GHz  | 512MB | X580PRO | SO2 (せンシノキオク)                                                                  |
 |  012A | P4 2.8GHz  | 512MB | 9600XT  |                                                                                     |
+|  013A | P4 2.8GHz  | 512MB | 9600PRO | Used in BG4 Tuned Pro cabinets                                                      |
 |  024A | P4 2.8Ghz  | 1GB   | 9800PRO | HALF-LIFE2 VER2.0 Ver.2.07a-JPN                                                     |
 
 ## Type X7


### PR DESCRIPTION
The Type X+ 013A is used in Battle Gear 4 Tuned pro. It is pretty much identical to the 005 and 005B that is used in SD cabinets except it uses a more powerful 9800PRO due to the higher resolution (Tuned in pro mode runs at 1366x768 instead of 800x600). Unfortunately dont have the HDD label for tuned pro though. Also updated info for the 005A variant which ive seen in european BG4 cabinets.