### PR TITLE
Add some wangan midnight version numbers

### DIFF
--- a/namco/products.md
+++ b/namco/products.md
@@ -27,9 +27,11 @@ V233 - Truck Kyosokyoku
 V239 - 
 V257 - Ridge Racer V
 V260 - 
+V281 - Wangan Midnight JP?
 V290 - 
 V291 - Time Crisis 3
 V300 -
+V307 - Wangan Midnight Maximum Tune
 V315 - Wangan Midnight Maximum Tune 2
 V320 -
 V329 - Time Crisis 4
@@ -37,7 +39,7 @@ V337 - Wangan Midnight Maximum Tune 3
 V349 - 
 V351 - Nirin
 V352 - Tank!Tank!Tank!
-V363 - Wangan Midnight Maximum Tune 3
+V363 - Wangan Midnight Maximum Tune 3DX
 V371 - 
 V376 - 
 V386 - Wangan Midnight Maximum Tune 3DX+


### PR DESCRIPTION
100% sure about V363 being 3DX and not 3, also sure that V307 is wmmt1 (The boot xbe for wmmt1 is called `V307.xbe`). Im almost certain about wangan midnight JP but I still want some better confirmation. At address `0x185C20` in one of the boot elf executables on the magicgate dongle is the string for a device at `mc0:V257DRV`. V257 is the version code for ridge racer v (So I assume that they share the same str pcb for force feedback, and it would make sense since they both use the same 246 pcb, though I cant confirm). Further down at `0x189C98` is a version number which is `V281`. I believe this is the correct version number for WMN1.