### PR TITLE
Update information of maimai DX 2022 USB

### DIFF
--- a/sega/media.md
+++ b/sega/media.md
@@ -1407,6 +1407,7 @@ MDA-U0083 : maimai DX                     : ALLS HX2 : JPN : SDEZ
 MDA-U0084 :
 MDA-U0085 : maimai DX                     : ALLS HX2 : EXP : SDGA
 MDA-U0086 : maimai DX 2021                : ALLS HX2 : CHN : SDGB
+        D : maimai DX 2022                : ALLS HX2 : CHN : SDGB #DOC:Wahlap:Maimai DX 2022 Software Upgrading Guidance
 MDA-U0087 :
 MDA-U0088 :
 MDA-U0089 :


### PR DESCRIPTION
Extra information: the USB flash drive (MDA-U0086D) is contained in a box marked `XKT-2392-EX1, SOFT KIT MMT 1.2CHN`.