### PR TITLE
Update and fix iidx copula and pendual display specs

### DIFF
--- a/konami/product/GULDJ-JI.md
+++ b/konami/product/GULDJ-JI.md
@@ -1,0 +1,17 @@
+# `GULDJ-JI`: Beatmania IIDX PENDUAL LCD monitor
+
+* "PENDUAL LCD"
+* Monitor manufacturer: Konami Digital Entertainment
+* Panel: YTE (model unknown)
+* Size: 42"
+  * Visible size is 37". The remainder of the display area is covered by the bezel around the screen
+  * The input image is downscaled to the 37" visible area by the firmware of the monitor
+* Weight: 46kg
+* Power
+  * Voltage: AC100V
+  * Consumption: 100W
+  * Rated frequnecy: 50/60Hz
+* Native resolution: ???
+* Input: VGA, DVI
+* Known "manufacturing numbers" (`_` are redacted parts creating the unique identifier)
+  * `LDJUJIM_____` #WEB:https://twitter.com/kururusky/status/1601190433240936449/photo/1`

--- a/konami/product/GULDJ-JJ.md
+++ b/konami/product/GULDJ-JJ.md
@@ -1,8 +1,14 @@
-# `GULDJ-JJ`: Beatmania IIDX PENDUAL LCD monitor
+# `GULDJ-JJ`: Beatmania IIDX COPULA LCD monitor
 
-* "PENDUAL LCD"
-* Monitor manufacturer: Konami Digital Entertainment
-* Panel: YTE (model unknown)
-* Size: 37"
+* "COPULA LCD"
+* Size: 42"
+* Weight: 46kg
+* Power
+  * Voltage: AC100V
+  * Consumption: 100W
+  * Rated frequnecy: 50/60Hz
 * Native resolution: ???
 * Input: VGA, DVI
+* Known "manufacturing numbers" (`_` are redacted parts creating the unique identifier)
+  * `LDJUJJM_____` #WEB:https://twitter.com/kururusky/status/1601190433240936449/photo/1`
+  * `LDJQJC_____` #WEB:https://twitter.com/kururusky/status/1601190433240936449/photo/1`

--- a/konami/products.md
+++ b/konami/products.md
@@ -2134,7 +2134,7 @@ unknown:
   - `GULDJ-JG`: SPADA LCD monitor  `#WEB:http://kururusky.com/?p=1458`
   - [`GULDJ-JH`: PENDUAL version up kit](product/GULDJ-JH.md) (Japan)  `#WEB:https://blog.flipflop-jp.com/archives/3391/post-3391/`
   - [`GULDJ-AH`: PENDUAL version up kit](product/GULDJ-JH.md) (Japan)  `#WEB:https://blog.flipflop-jp.com/archives/3391/post-3391/`
-  - `GULDJ-JI`: PENDUAL LCD monitor  `#WEB:http://kururusky.com/?p=1458`
+  - [`GULDJ-JI`: PENDUAL LCD monitor](product/GULDJ-JI.md)  `#WEB:http://kururusky.com/?p=1458`
   - [`GULDJ-JJ`: copula LCD monitor](product/GULDJ-JJ.md)  `#WEB:http://kururusky.com/?p=1458 #WEB:https://page.auctions.yahoo.co.jp/jp/auction/h548227658`
   - `GCLDJ-JK`: copula conversion kit  `#WEB:https://page.auctions.yahoo.co.jp/jp/auction/q1025004961`
   - `GULDJ-JL`: SINOBUZ version up kit


### PR DESCRIPTION
- Product identifiers swapped JI <-> JJ
- Add more information based on pictures of various "model spec labels" that are located on the back of the monitor. These were taken from different monitors which revealed different "manufacturing numbers" among the same model. Probably reflecting different build revisions of the same model